### PR TITLE
app.py のリファクタリング

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -52,20 +52,22 @@ def contest_get():
 
 @app.route('/submited', methods=['POST'])
 def submit():
-    if (request.form.get('description') is not None or request.form.get('url') is not None) and request.form.get('title'):
-        newEditorial = Editorial(
-            title=request.form.get('title'),
-            description=request.form.get('description'),
-            contestname=request.form.get('contestname'),
-            url=request.form.get('url'),
-            user_image_url=current_user.user_image_url,
-            username=current_user.username
-        )
+    params = {
+        title: request.form.get('title'),
+        description: request.form.get('description'),
+        contestname: request.form.get('contestname'),
+        url: request.form.get('url'),
+        user_image_url: current_user.user_image_url,
+        username: current_user.username
+    }
+
+    if (params['description'] is not None or params['url'] is not None) and params['title'] is not None:
+        newEditorial = Editorial(**params)
         db.session.add(newEditorial)
         db.session.commit()
         return render_template('submited.html')
     else:
-        if request.form.get('title') is None:
+        if params['title'] is None:
             return render_template('error.html', message='Error:タイトルを入力して下さい。')
         else:
             return render_template('error.html', message='Error:URLまたは解説文を入力して下さい。')

--- a/app/app.py
+++ b/app/app.py
@@ -40,7 +40,7 @@ def contest_search():
 @app.route('/search/contest', methods=['POST'])
 def contest_get():
     if request.form['contestname']:
-        #データベースからコンテスト名と等しいものを取得する
+        # データベースからコンテスト名と等しいものを取得する
         editorials = Editorial.query.filter_by(contestname=request.form['contestname']).all()
 
         return render_template('contest.html', contestname=request.form.get('contestname'), editorials=editorials)

--- a/app/app.py
+++ b/app/app.py
@@ -84,7 +84,7 @@ def oauth_callback():
     )
 
     profile=oauth_session.get('account/verify_credentials.json').json()
-    
+
     twitter_id=str(profile.get('id'))
     username=str(profile.get('name'))
     description=str(profile.get('description'))
@@ -100,7 +100,7 @@ def oauth_callback():
         description=description,
         user_image_url=profile_image_url)
         db.session.add(user)
-    
+
     db.session.commit()
     login_user(user,True)
     return redirect(url_for('index'))

--- a/app/app.py
+++ b/app/app.py
@@ -50,7 +50,7 @@ def contest_get():
 
 @app.route('/submited', methods=["POST"])
 def submit():
-    if (request.form.get('description') != None or request.form.get('url') != None) and request.form.get('title'):
+    if (request.form.get('description') is not None or request.form.get('url') is not None) and request.form.get('title'):
         newEditorial = Editorial(
             title=request.form.get('title'),
             description=request.form.get('description'),
@@ -63,7 +63,7 @@ def submit():
         db.session.commit()
         return render_template("submited.html")
     else:
-        if request.form.get('title') == None:
+        if request.form.get('title') is None:
             return render_template("error.html", message="Error:タイトルを入力して下さい。")
         else:
             return render_template("error.html", message="Error:URLまたは解説文を入力して下さい。")

--- a/app/app.py
+++ b/app/app.py
@@ -4,8 +4,8 @@ from flask_migrate import Migrate
 from flask_login import UserMixin,LoginManager,login_user,logout_user,current_user
 from datetime import datetime
 from rauth import OAuth1Service
-
 from config import app,db,service,login_manager
+
 
 class User(UserMixin,db.Model):
     id=db.Column(db.Integer,primary_key=True)
@@ -14,6 +14,7 @@ class User(UserMixin,db.Model):
     user_image_url=db.Column(db.String(1024),index=True)
     date_published=db.Column(db.DateTime,nullable=False,default=datetime.utcnow)
     twitter_id=db.Column(db.String(64),nullable=False,unique=True)
+
 
 class Editorial(db.Model):
     id=db.Column(db.Integer,primary_key=True)
@@ -46,6 +47,7 @@ def contest_get():
     else:
         return render_template('error.html',message="Error:指定されたコンテストが見つかりません、もう一度お確かめください。")
 
+
 @app.route('/submited',methods=["POST"])
 def submit():
     if (request.form.get('description',None)!=None or request.form.get('url',None)!=None) and request.form.get('title',None):
@@ -65,6 +67,7 @@ def logout():
     logout_user()
     return redirect(url_for('index'))
 
+
 @app.route('/oauth/twitter')
 def oauth_authorize():
     if not current_user.is_anonymous:
@@ -73,6 +76,7 @@ def oauth_authorize():
         request_token=service.get_request_token(params={'oauth_callback':url_for('oauth_callback',provider='twitter',_external=True)})
         session['request_token']=request_token
         return redirect(service.get_authorize_url(request_token[0]))
+
 
 @app.route('/oauth/twitter/callback')
 def oauth_callback():
@@ -109,6 +113,7 @@ def oauth_callback():
 @login_manager.user_loader
 def load_user(id):
     return User.query.get(int(id))
+
 
 @app.cli.command('initdb')
 def initdb_command():

--- a/app/app.py
+++ b/app/app.py
@@ -39,11 +39,13 @@ def contest_search():
 
 @app.route('/search/contest', methods=['POST'])
 def contest_get():
-    if request.form['contestname']:
-        # データベースからコンテスト名と等しいものを取得する
-        editorials = Editorial.query.filter_by(contestname=request.form['contestname']).all()
+    contestname = request.form.get('contestname')
 
-        return render_template('contest.html', contestname=request.form.get('contestname'), editorials=editorials)
+    if contestname is not None:
+        # データベースからコンテスト名と等しいものを取得する
+        editorials = Editorial.query.filter_by(contestname=contestname).all()
+
+        return render_template('contest.html', contestname=contestname, editorials=editorials)
     else:
         return render_template('error.html', message='Error:指定されたコンテストが見つかりません、もう一度お確かめください。')
 

--- a/app/app.py
+++ b/app/app.py
@@ -51,7 +51,14 @@ def contest_get():
 @app.route('/submited', methods=["POST"])
 def submit():
     if (request.form.get('description', None) != None or request.form.get('url', None) != None) and request.form.get('title', None):
-        newEditorial = Editorial(title=request.form.get('title', None), description=request.form.get('description', None), contestname=request.form.get('contestname', None), url=request.form.get('url', None), user_image_url=current_user.user_image_url, username=current_user.username)
+        newEditorial = Editorial(
+            title=request.form.get('title', None),
+            description=request.form.get('description', None),
+            contestname=request.form.get('contestname', None),
+            url=request.form.get('url', None),
+            user_image_url=current_user.user_image_url,
+            username=current_user.username
+        )
         db.session.add(newEditorial)
         db.session.commit()
         return render_template("submited.html")
@@ -73,7 +80,9 @@ def oauth_authorize():
     if not current_user.is_anonymous:
         return redirect(url_for('index'))
     else:
-        request_token = service.get_request_token(params={'oauth_callback':url_for('oauth_callback', provider='twitter', _external=True)})
+        request_token = service.get_request_token(params={
+            'oauth_callback': url_for('oauth_callback', provider='twitter', _external=True)
+        })
         session['request_token'] = request_token
         return redirect(service.get_authorize_url(request_token[0]))
 
@@ -84,7 +93,9 @@ def oauth_callback():
     oauth_session = service.get_auth_session(
         request_token[0],
         request_token[1],
-        data={'oauth_verifier':request.args['oauth_verifier']}
+        data={
+            'oauth_verifier': request.args['oauth_verifier']
+        }
     )
 
     profile = oauth_session.get('account/verify_credentials.json').json()
@@ -99,10 +110,12 @@ def oauth_callback():
         user.twitter_id = twitter_id
         user.username = username
     else:
-        user = User(twitter_id=twitter_id,
-        username=username,
-        description=description,
-        user_image_url=profile_image_url)
+        user = User(
+            twitter_id=twitter_id,
+            username=username,
+            description=description,
+            user_image_url=profile_image_url
+        )
         db.session.add(user)
 
     db.session.commit()

--- a/app/app.py
+++ b/app/app.py
@@ -32,12 +32,12 @@ def index():
     return render_template('index.html')
 
 
-@app.route('/search', methods=["GET"])
+@app.route('/search', methods=['GET'])
 def contest_search():
     return render_template('search.html')
 
 
-@app.route('/search/contest', methods=["POST"])
+@app.route('/search/contest', methods=['POST'])
 def contest_get():
     if request.form['contestname']:
         #データベースからコンテスト名と等しいものを取得する
@@ -45,10 +45,10 @@ def contest_get():
 
         return render_template('contest.html', contestname=request.form.get('contestname'), editorials=editorials)
     else:
-        return render_template('error.html', message="Error:指定されたコンテストが見つかりません、もう一度お確かめください。")
+        return render_template('error.html', message='Error:指定されたコンテストが見つかりません、もう一度お確かめください。')
 
 
-@app.route('/submited', methods=["POST"])
+@app.route('/submited', methods=['POST'])
 def submit():
     if (request.form.get('description') is not None or request.form.get('url') is not None) and request.form.get('title'):
         newEditorial = Editorial(
@@ -61,12 +61,12 @@ def submit():
         )
         db.session.add(newEditorial)
         db.session.commit()
-        return render_template("submited.html")
+        return render_template('submited.html')
     else:
         if request.form.get('title') is None:
-            return render_template("error.html", message="Error:タイトルを入力して下さい。")
+            return render_template('error.html', message='Error:タイトルを入力して下さい。')
         else:
-            return render_template("error.html", message="Error:URLまたは解説文を入力して下さい。")
+            return render_template('error.html', message='Error:URLまたは解説文を入力して下さい。')
 
 
 @app.route('/logout')
@@ -133,5 +133,5 @@ def initdb_command():
     db.create_all()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     app.run(debug=True)

--- a/app/app.py
+++ b/app/app.py
@@ -43,19 +43,19 @@ def contest_get():
         #データベースからコンテスト名と等しいものを取得する
         editorials = Editorial.query.filter_by(contestname=request.form['contestname']).all()
 
-        return render_template('contest.html', contestname=request.form.get('contestname', None), editorials=editorials)
+        return render_template('contest.html', contestname=request.form.get('contestname'), editorials=editorials)
     else:
         return render_template('error.html', message="Error:指定されたコンテストが見つかりません、もう一度お確かめください。")
 
 
 @app.route('/submited', methods=["POST"])
 def submit():
-    if (request.form.get('description', None) != None or request.form.get('url', None) != None) and request.form.get('title', None):
+    if (request.form.get('description') != None or request.form.get('url') != None) and request.form.get('title'):
         newEditorial = Editorial(
-            title=request.form.get('title', None),
-            description=request.form.get('description', None),
-            contestname=request.form.get('contestname', None),
-            url=request.form.get('url', None),
+            title=request.form.get('title'),
+            description=request.form.get('description'),
+            contestname=request.form.get('contestname'),
+            url=request.form.get('url'),
             user_image_url=current_user.user_image_url,
             username=current_user.username
         )
@@ -63,7 +63,7 @@ def submit():
         db.session.commit()
         return render_template("submited.html")
     else:
-        if request.form.get('title', None) == None:
+        if request.form.get('title') == None:
             return render_template("error.html", message="Error:タイトルを入力して下さい。")
         else:
             return render_template("error.html", message="Error:URLまたは解説文を入力して下さい。")

--- a/app/app.py
+++ b/app/app.py
@@ -8,23 +8,23 @@ from config import app, db, service, login_manager
 
 
 class User(UserMixin,db.Model):
-    id=db.Column(db.Integer, primary_key=True)
-    username=db.Column(db.String(64), index=True)
-    description=db.Column(db.String(1024), index=True)
-    user_image_url=db.Column(db.String(1024), index=True)
-    date_published=db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    twitter_id=db.Column(db.String(64), nullable=False, unique=True)
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(64), index=True)
+    description = db.Column(db.String(1024), index=True)
+    user_image_url = db.Column(db.String(1024), index=True)
+    date_published = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    twitter_id = db.Column(db.String(64), nullable=False, unique=True)
 
 
 class Editorial(db.Model):
-    id=db.Column(db.Integer, primary_key=True)
-    username=db.Column(db.String(64))
-    contestname=db.Column(db.String(64))
-    title=db.Column(db.String(64))
-    url=db.Column(db.String(120))
-    description=db.Column(db.String(1024))
-    like=db.Column(db.Integer)
-    user_image_url=db.Column(db.String(1024), index=True)
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(64))
+    contestname = db.Column(db.String(64))
+    title = db.Column(db.String(64))
+    url = db.Column(db.String(120))
+    description = db.Column(db.String(1024))
+    like = db.Column(db.Integer)
+    user_image_url = db.Column(db.String(1024), index=True)
 
 
 @app.route('/')
@@ -41,7 +41,7 @@ def contest_search():
 def contest_get():
     if request.form['contestname']:
         #データベースからコンテスト名と等しいものを取得する
-        editorials=Editorial.query.filter_by(contestname=request.form['contestname']).all()
+        editorials = Editorial.query.filter_by(contestname=request.form['contestname']).all()
 
         return render_template('contest.html', contestname=request.form.get('contestname', None), editorials=editorials)
     else:
@@ -50,13 +50,13 @@ def contest_get():
 
 @app.route('/submited', methods=["POST"])
 def submit():
-    if (request.form.get('description', None)!=None or request.form.get('url', None)!=None) and request.form.get('title', None):
-        newEditorial=Editorial(title=request.form.get('title', None), description=request.form.get('description', None), contestname=request.form.get('contestname', None), url=request.form.get('url', None), user_image_url=current_user.user_image_url, username=current_user.username)
+    if (request.form.get('description', None) != None or request.form.get('url', None) != None) and request.form.get('title', None):
+        newEditorial = Editorial(title=request.form.get('title', None), description=request.form.get('description', None), contestname=request.form.get('contestname', None), url=request.form.get('url', None), user_image_url=current_user.user_image_url, username=current_user.username)
         db.session.add(newEditorial)
         db.session.commit()
         return render_template("submited.html")
     else:
-        if request.form.get('title', None)==None:
+        if request.form.get('title', None) == None:
             return render_template("error.html", message="Error:タイトルを入力して下さい。")
         else:
             return render_template("error.html", message="Error:URLまたは解説文を入力して下さい。")
@@ -73,33 +73,33 @@ def oauth_authorize():
     if not current_user.is_anonymous:
         return redirect(url_for('index'))
     else:
-        request_token=service.get_request_token(params={'oauth_callback':url_for('oauth_callback', provider='twitter', _external=True)})
-        session['request_token']=request_token
+        request_token = service.get_request_token(params={'oauth_callback':url_for('oauth_callback', provider='twitter', _external=True)})
+        session['request_token'] = request_token
         return redirect(service.get_authorize_url(request_token[0]))
 
 
 @app.route('/oauth/twitter/callback')
 def oauth_callback():
-    request_token=session.pop('request_token')
-    oauth_session=service.get_auth_session(
+    request_token = session.pop('request_token')
+    oauth_session = service.get_auth_session(
         request_token[0],
         request_token[1],
         data={'oauth_verifier':request.args['oauth_verifier']}
     )
 
-    profile=oauth_session.get('account/verify_credentials.json').json()
+    profile = oauth_session.get('account/verify_credentials.json').json()
 
-    twitter_id=str(profile.get('id'))
-    username=str(profile.get('name'))
-    description=str(profile.get('description'))
-    profile_image_url=str(profile.get('profile_image_url'))
-    user=db.session.query(User).filter(User.twitter_id==twitter_id).first()
+    twitter_id = str(profile.get('id'))
+    username = str(profile.get('name'))
+    description = str(profile.get('description'))
+    profile_image_url = str(profile.get('profile_image_url'))
+    user = db.session.query(User).filter(User.twitter_id == twitter_id).first()
 
     if user:
-        user.twitter_id=twitter_id
-        user.username=username
+        user.twitter_id = twitter_id
+        user.username = username
     else:
-        user=User(twitter_id=twitter_id,
+        user = User(twitter_id=twitter_id,
         username=username,
         description=description,
         user_image_url=profile_image_url)
@@ -120,5 +120,5 @@ def initdb_command():
     db.create_all()
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     app.run(debug=True)

--- a/app/app.py
+++ b/app/app.py
@@ -1,30 +1,30 @@
-from flask import Flask,render_template,request,url_for,redirect,session
+from flask import Flask, render_template, request,url_for, redirect,session
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-from flask_login import UserMixin,LoginManager,login_user,logout_user,current_user
+from flask_login import UserMixin, LoginManager, login_user, logout_user, current_user
 from datetime import datetime
 from rauth import OAuth1Service
-from config import app,db,service,login_manager
+from config import app, db, service, login_manager
 
 
 class User(UserMixin,db.Model):
-    id=db.Column(db.Integer,primary_key=True)
-    username=db.Column(db.String(64),index=True)
-    description=db.Column(db.String(1024),index=True)
-    user_image_url=db.Column(db.String(1024),index=True)
-    date_published=db.Column(db.DateTime,nullable=False,default=datetime.utcnow)
-    twitter_id=db.Column(db.String(64),nullable=False,unique=True)
+    id=db.Column(db.Integer, primary_key=True)
+    username=db.Column(db.String(64), index=True)
+    description=db.Column(db.String(1024), index=True)
+    user_image_url=db.Column(db.String(1024), index=True)
+    date_published=db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    twitter_id=db.Column(db.String(64), nullable=False, unique=True)
 
 
 class Editorial(db.Model):
-    id=db.Column(db.Integer,primary_key=True)
+    id=db.Column(db.Integer, primary_key=True)
     username=db.Column(db.String(64))
     contestname=db.Column(db.String(64))
     title=db.Column(db.String(64))
     url=db.Column(db.String(120))
     description=db.Column(db.String(1024))
     like=db.Column(db.Integer)
-    user_image_url=db.Column(db.String(1024),index=True)
+    user_image_url=db.Column(db.String(1024), index=True)
 
 
 @app.route('/')
@@ -32,34 +32,34 @@ def index():
     return render_template('index.html')
 
 
-@app.route('/search',methods=["GET"])
+@app.route('/search', methods=["GET"])
 def contest_search():
     return render_template('search.html')
 
 
-@app.route('/search/contest',methods=["POST"])
+@app.route('/search/contest', methods=["POST"])
 def contest_get():
     if request.form['contestname']:
         #データベースからコンテスト名と等しいものを取得する
         editorials=Editorial.query.filter_by(contestname=request.form['contestname']).all()
 
-        return render_template('contest.html',contestname=request.form.get('contestname',None),editorials=editorials)
+        return render_template('contest.html', contestname=request.form.get('contestname', None), editorials=editorials)
     else:
-        return render_template('error.html',message="Error:指定されたコンテストが見つかりません、もう一度お確かめください。")
+        return render_template('error.html', message="Error:指定されたコンテストが見つかりません、もう一度お確かめください。")
 
 
-@app.route('/submited',methods=["POST"])
+@app.route('/submited', methods=["POST"])
 def submit():
-    if (request.form.get('description',None)!=None or request.form.get('url',None)!=None) and request.form.get('title',None):
-        newEditorial=Editorial(title=request.form.get('title',None),description=request.form.get('description',None),contestname=request.form.get('contestname',None),url=request.form.get('url',None),user_image_url=current_user.user_image_url,username=current_user.username)
+    if (request.form.get('description', None)!=None or request.form.get('url', None)!=None) and request.form.get('title', None):
+        newEditorial=Editorial(title=request.form.get('title', None), description=request.form.get('description', None), contestname=request.form.get('contestname', None), url=request.form.get('url', None), user_image_url=current_user.user_image_url, username=current_user.username)
         db.session.add(newEditorial)
         db.session.commit()
         return render_template("submited.html")
     else:
-        if request.form.get('title',None)==None:
-            return render_template("error.html",message="Error:タイトルを入力して下さい。")
+        if request.form.get('title', None)==None:
+            return render_template("error.html", message="Error:タイトルを入力して下さい。")
         else:
-            return render_template("error.html",message="Error:URLまたは解説文を入力して下さい。")
+            return render_template("error.html", message="Error:URLまたは解説文を入力して下さい。")
 
 
 @app.route('/logout')
@@ -73,7 +73,7 @@ def oauth_authorize():
     if not current_user.is_anonymous:
         return redirect(url_for('index'))
     else:
-        request_token=service.get_request_token(params={'oauth_callback':url_for('oauth_callback',provider='twitter',_external=True)})
+        request_token=service.get_request_token(params={'oauth_callback':url_for('oauth_callback', provider='twitter', _external=True)})
         session['request_token']=request_token
         return redirect(service.get_authorize_url(request_token[0]))
 
@@ -106,7 +106,7 @@ def oauth_callback():
         db.session.add(user)
 
     db.session.commit()
-    login_user(user,True)
+    login_user(user, True)
     return redirect(url_for('index'))
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -27,6 +27,12 @@ class Editorial(db.Model):
     user_image_url = db.Column(db.String(1024), index=True)
 
 
+def _normalize_contestname(contestname):
+    if isinstance(contestname, str):
+        contestname = contestname.strip()
+    return contestname
+
+
 @app.route('/')
 def index():
     return render_template('index.html')
@@ -39,7 +45,7 @@ def contest_search():
 
 @app.route('/search/contest', methods=['POST'])
 def contest_get():
-    contestname = request.form.get('contestname')
+    contestname = _normalize_contestname(request.form.get('contestname'))
 
     if contestname is not None:
         # データベースからコンテスト名と等しいものを取得する
@@ -55,7 +61,7 @@ def submit():
     params = {
         title: request.form.get('title'),
         description: request.form.get('description'),
-        contestname: request.form.get('contestname'),
+        contestname: _normalize_contestname(request.form.get('contestname')),
         url: request.form.get('url'),
         user_image_url: current_user.user_image_url,
         username: current_user.username


### PR DESCRIPTION
雰囲気でリファクタリングしたので、もしかしたら動かなかったりエンバグしている箇所があるかもしれません。

### 変更点

- 051e184 remove traling spaces, add newline at EOF
    - 行末尾のスペースを削除、ファイル末尾に改行を追加
- dafae87 keep two blank lines at global context
    - インデントが0の行は直前に空行を2つ付ける
- fc97ee4 keep a space after a comma
    - カンマの直後はスペースを置く
- b0cf547 keep a space on both sides of a operator excluding kwargs
    - 演算子の前後にスペースを置く（キーワード引数のイコール前後にはスペースを置かない）
- c379656 text wrap in long params
    - dict や args が長い場合は折り返す
- e81d497 remove the value "None" in second argument of dict.get()
    - dict.get() メソッドは第2引数を省略すると None が返るので、第2引数に None は不要
- 6a7c56d use "is / is not" instead of "== / !=" to compare to "None"
    - None との比較には `== / !=` ではなく `is / is not` 演算子を使う（"python none is" などでWeb検索すれば情報が出てくる）
- de08ad6 use single-quotation for a string literal
    - 文字列リテラルにはシングルクォーテーションを使う（ダブルクォーテーションでもよいが、どちらかに統一しておく）
- 6f914dd keep a space after a comment delimiter
    - コメント区切りの直後はスペースから始める
- d153b5d avoid direct access to request.form['contestname']
    - `request.form` が `contestname` を持たない場合に KeyError 例外が発生するので dict.get() を使う
- 8ab6b60 uniformed params checking in submit method
    - パラメータの存在確認に `is not None` を使うように統一する
    - 何度も `dict.get()` を呼ばないように変数 `params` に値を保持しておく
- 62babce add _normalize_contestname method
    - `contestname` の先頭と末尾の空白を取り除いてから使うようにする

### 備考

- https://github.com/null-null-programming/AtCoderEditorials/blob/edebfd777c8e2a498b690c7b1daccdef65435888/app/app.py#L49
    - `submited` ではなく `submitted` が正しい
- https://github.com/null-null-programming/AtCoderEditorials/blob/edebfd777c8e2a498b690c7b1daccdef65435888/app/app.py#L88-L91
    - `str()` にキャストしているが、パラメータが存在しないときの値が文字列 `"None"` になってしまう